### PR TITLE
Update README.md and install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ BACKUP YOUR magicband.py BEFORE UPGRADING so you don't lose you sequences config
 * See YouTube video https://youtu.be/HJ8CTLgmcSk  (UPDATED video coming June 15th 2020) 
 
 * Install Raspbian lite onto pi. BE SURE TO INSTALL THE LITE VERSION: https://www.raspberrypi.org/downloads/raspberry-pi-os/ 
-* Download magicbandreader-master from github (the big green "CLONE OR DOWNLOAD" button)
-* Copy magicbandreader.zip to pi and unzip it
-* cd magicband-reader-master
+* Add ssh file and wpa_supplicant.conf to boot partition for wireless SSH access or log directly into Pi
+* sudo apt install git
+* git clone https://github.com/foolishmortalbuilders/magicbandreader.git
+* cd magicbandreader
 * sudo sh install.sh  (this will take awhile)
 * cp * /home/pi/.
 * sudo reboot now

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 sudo apt-get -y upgrade
 sudo apt-get install -y python3 python3-pip 
-sudo apt-get install -y libsdl1.2-dev libsdl-mixer1.2
+sudo apt-get install -y libsdl1.2-dev libsdl-mixer1.2 libsdl2-mixer-2.0-0
 sudo pip3 install rpi_ws281x adafruit-circuitpython-neopixel
 sudo apt-get install -y python-smbus
 sudo pip3 install --upgrade setuptools


### PR DESCRIPTION
Updated installation steps to reduce manual copying of files to the Pi. Especially useful if setting up headless. Also, sudo python3 magicband.py would not run without libsdl2-mixer-2.0-0 installed; added to install.sh.